### PR TITLE
Update default Server SDK version to 8.2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <server-sdk.version>8.1.0.0</server-sdk.version>
+    <server-sdk.version>8.2.0.0</server-sdk.version>
   </properties>
 
   <profiles>

--- a/server-sdk-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/server-sdk-archetype/src/main/resources/archetype-resources/pom.xml
@@ -33,10 +33,10 @@
     <!--
     The Server SDK version for which this extension will be built.
 
-    EXAMPLE:  <server-sdk.version>8.1.0.0</server-sdk.version>
-    EXAMPLE:  <server-sdk.version>8.2.0.0-EA</server-sdk.version>
+    EXAMPLE:  <server-sdk.version>8.2.0.0</server-sdk.version>
+    EXAMPLE:  <server-sdk.version>8.3.0.0-EA</server-sdk.version>
     -->
-    <server-sdk.version>8.1.0.0</server-sdk.version>
+    <server-sdk.version>8.2.0.0</server-sdk.version>
 
     <!--
     The Maven version string of the Server SDK dependency to build against.


### PR DESCRIPTION
Server SDK version 8.2.0.0 was just pushed out to Maven Central. This updates the parent POM and archetype to use that.

Resolves #27