### PR TITLE
Remove server-sdk.maven-version

### DIFF
--- a/server-sdk-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/server-sdk-archetype/src/main/resources/archetype-resources/pom.xml
@@ -38,6 +38,7 @@
     usually corresponds to the product version of your PingData server.
 
     EXAMPLE:  <server-sdk.version>8.2.0.0</server-sdk.version>
+    EXAMPLE:  <server-sdk.version>8.3.0.0-SNAPSHOT</server-sdk.version>
     EXAMPLE:  <server-sdk.version>8.3.0.0-EA</server-sdk.version>
     -->
     <server-sdk.version>8.2.0.0</server-sdk.version>
@@ -55,15 +56,6 @@
     -->
     <source.version>1.8</source.version>
     <target.version>1.8</target.version>
-
-    <!--
-    The Maven version string of the Server SDK dependency to build against.
-    In general, you should only need to change this if you are building with
-    a snapshot build of the Server SDK.
-
-    EXAMPLE:  <server-sdk.maven-version>8.1.0.0-SNAPSHOT</server-sdk.maven-version>
-    -->
-    <server-sdk.maven-version>${server-sdk.version}</server-sdk.maven-version>
 
     <!--
     The name for this extension or set of extensions. It must begin with an
@@ -222,8 +214,9 @@
             <!--
             The manage-extension tool will reject an extension bundle if the
             bundle's manifest includes an UnboundID-Server-SDK-Version value
-            with a qualifier, such as "8.2.0.0-EA". This strips the qualifier,
-            producing an UnboundID-Server-SDK-Version value like "8.2.0.0".
+            with a qualifier, such as "8.2.0.0-EA" or "8.2.0.0-SNAPSHOT". 
+            This strips the qualifier, producing an UnboundID-Server-SDK-Version
+            value like "8.2.0.0".
             -->
             <id>set-server-sdk-jar-version</id>
             <goals>
@@ -232,7 +225,7 @@
             <configuration>
               <name>server-sdk.jar-version</name>
               <value>${server-sdk.version}</value>
-              <regex>-EA$</regex>
+              <regex>-(EA|SNAPSHOT)$</regex>
               <replacement/>
               <failIfNoMatch>false</failIfNoMatch>
             </configuration>
@@ -286,7 +279,7 @@
           <dependency>
             <groupId>com.unboundid</groupId>
             <artifactId>server-sdk</artifactId>
-            <version>${server-sdk.maven-version}</version>
+            <version>${server-sdk.version}</version>
           </dependency>
         </dependencies>
         <executions>
@@ -325,7 +318,7 @@
     <dependency>
       <groupId>com.unboundid</groupId>
       <artifactId>server-sdk</artifactId>
-      <version>${server-sdk.maven-version}</version>
+      <version>${server-sdk.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Commit message:

```
This replaces a workaround for PingData servers rejecting SNAPSHOT
extensions with one that does not require extension developers to
maintain a separate server-sdk.maven-version. The new workaround uses
the same maven-install-plugin mechanism that strips the '-EA' segment of
the versioning from the extension metadata. It now strips both '-EA' and
'-SNAPSHOT'.
```


Before:
```
[~/ds]$ bin/manage-extension --update ~/my-extension/target/com.example.example-extension-1.0-SNAPSHOT.zip 
Unpacking bundle archive ..... Done
An error occurred while opening the extension bundle:  Value '8.3.0.0-SNAPSHOT' for manifest attribute 'UnboundID-Server-SDK-Version' is malformed
```

After:
```
[~/ds]$ bin/manage-extension --install ~/my-extension/target/com.example.example-extension-1.0-SNAPSHOT.zip 
Unpacking bundle archive ..... Done
Loading extension bundle ..... Done


Extension bundle to install:

Name: example-extension
Version: 1.0-SNAPSHOT
Vendor: ExampleCorp
Support Contact: CHANGEME
Included Extensions:

Example Identity Mapper (com.example.MyExampleExtension)

  This is an example identity mapper extension that converts a username to an email address.

Continue? (yes / no) [no]: yes

The server will need to be stopped in order to proceed. Continue? (yes / no) [yes]: yes

Stopping Directory Server ..... Done
Copying files ..... Done
Starting Directory Server ..... Done


Extensions in the bundle were installed successfully but they may need to be configured for use. Please refer to
documentation at /home/developer/Build/master/ds/extensions/com.example.example-extension/docs/index.html for
configuration instructions

Extension bundle installed successfully
```